### PR TITLE
Factor out the CI binary size measurement as a separate Github action…

### DIFF
--- a/.github/actions/build-with-patched-std.yml
+++ b/.github/actions/build-with-patched-std.yml
@@ -1,0 +1,28 @@
+name: Build with patched std
+description: >
+  Build a binary with a version of std that's had a specific revision of
+  backtrace patched in.
+inputs:
+  backtrace-commit:
+    description: The git commit of backtrace to patch in to std
+    required: true
+  main-rs:
+    description: The (single) source code file to compile
+    required: true
+outputs:
+  test-binary-size:
+    description: The size in bytes of the built test binary
+runs:
+  using: "composite"
+  steps:
+    - name: Build binary with patched version of backtrace
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/stage0-std
+        (cd library/backtrace && git checkout ${{ inputs.backtrace-commit }})
+        git add library/backtrace
+        python3 x.py build library --stage 0
+        cp -r ./build/x86_64-unknown-linux-gnu/stage0/bin ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin
+        cp -r ./build/x86_64-unknown-linux-gnu/stage0/lib/*.so ./build/x86_64-unknown-linux-gnu/stage0-sysroot/lib
+        TEMP_BUILD_OUTPUT=$(mktemp test-binary)
+        ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O ${{ inputs.main-rs }} -o "$TEMP_BUILD_OUTPUT"
+        echo "$(stat -c '%s' binary-reference)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -15,51 +15,62 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      RUSTC_DIR: ./rustc
+      BACKTRACE_DIR: ./backtrace
     steps:
       - name: Print info
         run: |
           echo "Current SHA: ${{ github.event.pull_request.head.sha }}"
           echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
+      # Note: the backtrace source that's cloned here is NOT the version to be
+      # patched in to std. It is cloned here to access the Github action for
+      # building the test binary and measuring its size.
+      - name: Clone backtrace to access Github action
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: $BACKTRACE_DIR
       - name: Clone Rustc
         uses: actions/checkout@v3
         with:
           repository: rust-lang/rust
           fetch-depth: 1
-      - name: Fetch backtrace
-        run: git submodule update --init library/backtrace
-      - name: Create hello world program that uses backtrace
-        run: printf "fn main() { panic!(); }" > foo.rs
-      - name: Build binary with base version of backtrace
+          path: $RUSTC_DIR
+      - name: Set up std repository and backtrace submodule for size test
+        working-directory: $RUSTC_DIR
         run: |
+        run: git submodule update --init library/backtrace
           printf "[llvm]\ndownload-ci-llvm = true\n\n[rust]\nincremental = false\n" > config.toml
           cd library/backtrace
           git remote add head-pr https://github.com/${{ github.event.pull_request.head.repo.full_name }}
           git fetch --all
-          git checkout ${{ github.event.pull_request.base.sha }}
           cd ../..
-          git add library/backtrace
-          python3 x.py build library --stage 0
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/bin ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/lib/*.so ./build/x86_64-unknown-linux-gnu/stage0-sysroot/lib
-          ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-reference
-      - name: Build binary with PR version of backtrace
-        run: |
-          cd library/backtrace
-          git checkout ${{ github.event.pull_request.head.sha }}
-          cd ../..
-          git add library/backtrace
-          rm -rf build/x86_64-unknown-linux-gnu/stage0-std
-          python3 x.py build library --stage 0
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/bin ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/lib/*.so ./build/x86_64-unknown-linux-gnu/stage0-sysroot/lib
-          ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-updated
-      - name: Display binary size
-        run: |
-          ls -la binary-*
-          echo "SIZE_REFERENCE=$(stat -c '%s' binary-reference)" >> "$GITHUB_ENV"
-          echo "SIZE_UPDATED=$(stat -c '%s' binary-updated)" >> "$GITHUB_ENV"
+      - name: Create hello world program that uses backtrace
+        id: create-main-rs
+        working-directory: $RUSTC_DIR
+        env:
+          TEST_MAIN_RS: foo.rs
+        run: printf "fn main() { panic!(); }" > $TEST_MAIN_RS
+      - name: Compile binary with base version of backtrace
+        id: size-reference
+        working-directory: $RUSTC_DIR
+        uses: $BACKTRACE_DIR/.github/actions/build-with-patched-std
+        with:
+          backtrace-commit: ${{ github.event.pull_request.base.sha }}
+          main-rs: ${{ steps.create-main-rs.env.TEST_MAIN_RS }}
+      - name: Compile binary with PR version of backtrace
+        id: size-updated
+        working-directory: $RUSTC_DIR
+        uses: $BACKTRACE_DIR/.github/actions/build-with-patched-std
+        with:
+          backtrace-commit: ${{ github.event.pull_request.head.sha }}
+          main-rs: ${{ steps.create-main-rs.env.TEST_MAIN_RS }}
       - name: Post a PR comment if the size has changed
         uses: actions/github-script@v6
+        env:
+          SIZE_REFERENCE: ${{ steps.size-reference.output }}
+          SIZE_UPDATED: ${{ steps.size-updated.output }}
         with:
           script: |
             const reference = process.env.SIZE_REFERENCE;


### PR DESCRIPTION
… for easier tuning.

(Test PR for checking GH action.)